### PR TITLE
error: 테스트가 jacoco 설정 오류로 인해 오류가 발생한다. 이를 해결한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,4 +164,6 @@ jacocoTestReport {
 
 tasks.withType(Test) {
 	jacoco.includeNoLocationClasses = true
+	jacoco.excludes = ['jdk.internal.*']
 }
+


### PR DESCRIPTION
- jacoco.excludes = ['jdk.internal.*']를 추가해서 해결한다.

issue #41 