### PR TITLE
fix:ci/cd  파이프라인의 오류를 잡는다.

### DIFF
--- a/.github/workflows/github-actoins-docker-slack.yml
+++ b/.github/workflows/github-actoins-docker-slack.yml
@@ -34,7 +34,7 @@ jobs:
           ${{ runner.os }}-gradle-
 
     - uses: actions/checkout@v3
-    - run: touch ./src/main/resources/application.yml
+    - run: mkdir -p ./src/main/resources && touch ./src/main/resources/application.yml
     - run: touch ./src/test/resources/application-test.yml
     - run: echo "${{env.APPLICATION}}" > ./src/main/resources/application.yml
     - run: echo "${{env.APPLICATION_TEST}}" > ./src/test/resources/application-test.yml


### PR DESCRIPTION
resources 디렉터리가 없다면 생성하는 커멘드 추가