### PR TITLE
feature: 닉네임 변경 API를 개발한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ dependencies {
 	testImplementation "org.testcontainers:mysql:1.17.6"
 	testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.2'
 	testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.2'
+	testImplementation 'org.mockito:mockito-core:4.8.1'
 
 	// Google
 	implementation 'com.google.guava:guava:31.1-jre'

--- a/src/docs/asciidoc/hello.adoc
+++ b/src/docs/asciidoc/hello.adoc
@@ -79,6 +79,18 @@ include::{snippets}/post-stop-member/http-request.adoc[]
 include::{snippets}/post-stop-member/http-response.adoc[]
 include::{snippets}/post-stop-member/response-fields.adoc[]
 
+=== 멤버 본인 닉네임 변경
+파라미터로 주시면 됩니다.
+
+처음 생성 혹은 마지막 변경일자에서 30일 이상 지나야 닉네임 변경이 가능합니다.
+
+==== http request
+include::{snippets}/put-member-nickname/curl-request.adoc[]
+include::{snippets}/put-member-nickname/request-parameters.adoc[]
+
+==== http response
+include::{snippets}/put-member-nickname/http-response.adoc[]
+include::{snippets}/put-member-nickname/response-fields.adoc[]
 
 
 == Notification

--- a/src/main/java/cbnu/io/cbnuswalrami/business/core/domon/member/entity/Member.java
+++ b/src/main/java/cbnu/io/cbnuswalrami/business/core/domon/member/entity/Member.java
@@ -63,7 +63,13 @@ public class Member {
 
 
 
-    public Member(LoginId loginId, Password password, Nickname nickname, StudentNumber studentNumber, String userPictureUrl, Role role) {
+    public Member(LoginId loginId,
+                  Password password,
+                  Nickname nickname,
+                  StudentNumber studentNumber,
+                  String userPictureUrl,
+                  Role role
+    ) {
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
@@ -73,7 +79,12 @@ public class Member {
         this.isDeleted = Deleted.FALSE;
     }
 
-    public Member(LoginId loginId, Password password, Nickname nickname, StudentNumber studentNumber, String userPictureUrl) {
+    public Member(LoginId loginId,
+                  Password password,
+                  Nickname nickname,
+                  StudentNumber studentNumber,
+                  String userPictureUrl
+    ) {
         this.loginId = loginId;
         this.password = password;
         this.nickname = nickname;
@@ -94,6 +105,10 @@ public class Member {
 
     public void changeRole(Role role) {
         this.role = role;
+    }
+
+    public void changeNickname(String nickname) {
+        this.nickname = Nickname.from(nickname);
     }
 
     public Long getId() {

--- a/src/main/java/cbnu/io/cbnuswalrami/business/core/domon/member/entity/values/Nickname.java
+++ b/src/main/java/cbnu/io/cbnuswalrami/business/core/domon/member/entity/values/Nickname.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 @Embeddable
 public class Nickname {
 
-    private static final Pattern pattern = Pattern.compile("^(?=.*[a-z0-9ㄱ-ㅎ가-힣])[ㄱ-ㅎa-z0-9가-힣]{2,16}$");
+    private static final Pattern pattern = Pattern.compile("^(?=.*[\\p{IsHangul}\\p{IsAlphabetic}]).{3,39}$");
 
     private String nickname;
 

--- a/src/main/java/cbnu/io/cbnuswalrami/business/web/member/application/service/ChangeNicknameService.java
+++ b/src/main/java/cbnu/io/cbnuswalrami/business/web/member/application/service/ChangeNicknameService.java
@@ -1,0 +1,48 @@
+package cbnu.io.cbnuswalrami.business.web.member.application.service;
+
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.Member;
+import cbnu.io.cbnuswalrami.business.core.domon.member.infrastructure.command.MemberJpaRepository;
+import cbnu.io.cbnuswalrami.business.web.member.presentation.response.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class ChangeNicknameService {
+
+    private final MemberJpaRepository memberJpaRepository;
+
+    public MemberDto changeNickname(
+            String changeNickname,
+            Member member
+    ){
+        // 닉네임 변경 가능한지 검증(날짜) 검사
+        validateLastModifiedDate(member.getLastModifiedAt());
+
+        member.changeNickname(changeNickname);
+        memberJpaRepository.save(member);
+
+        MemberDto memberDto = new MemberDto(
+                member.getId(),
+                changeNickname,
+                member.getStudentNumber().getStudentNumber()
+        );
+
+        return memberDto;
+    }
+
+    private void validateLastModifiedDate(LocalDateTime memberLastModifiedDate) {
+        LocalDateTime now = LocalDateTime.now();
+        long dayBetween = ChronoUnit.DAYS.between(memberLastModifiedDate, now);
+
+        System.out.println("memberLastModifiedDate = " + memberLastModifiedDate);
+        System.out.println("dayBetween = " + dayBetween);
+
+        if (dayBetween < 30) {
+            throw new IllegalArgumentException("아직 마지막으로 유저정보를 바꾼지 30일이 지나지 않았습니다.");
+        }
+    }
+}

--- a/src/main/java/cbnu/io/cbnuswalrami/business/web/member/presentation/ChangeNicknameAPI.java
+++ b/src/main/java/cbnu/io/cbnuswalrami/business/web/member/presentation/ChangeNicknameAPI.java
@@ -1,0 +1,39 @@
+package cbnu.io.cbnuswalrami.business.web.member.presentation;
+
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.Member;
+import cbnu.io.cbnuswalrami.business.web.member.application.service.ChangeNicknameService;
+import cbnu.io.cbnuswalrami.business.web.member.presentation.response.MemberDto;
+import cbnu.io.cbnuswalrami.business.web.util.MemberFindUtil;
+import cbnu.io.cbnuswalrami.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/nickname")
+public class ChangeNicknameAPI {
+
+    private final MemberFindUtil memberFindUtil;
+
+    private final ChangeNicknameService changeNicknameService;
+
+    @PutMapping
+    public ResponseEntity<ApiResponse> changeNickname(
+            @RequestParam(value = "nickname") String nickname,
+            HttpServletRequest request
+            ) {
+        Member member = memberFindUtil.findMemberByBearerToken(request);
+
+        MemberDto memberDto = changeNicknameService.changeNickname(nickname, member);
+
+        return ResponseEntity
+                .ok()
+                .body(ApiResponse.of(memberDto));
+    }
+}

--- a/src/main/java/cbnu/io/cbnuswalrami/common/response/ApiResponse.java
+++ b/src/main/java/cbnu/io/cbnuswalrami/common/response/ApiResponse.java
@@ -1,12 +1,14 @@
 package cbnu.io.cbnuswalrami.common.response;
 
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import org.springframework.http.HttpStatus;
 
 import java.time.LocalDateTime;
 
 public final class ApiResponse<T> {
 
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm")
     private final LocalDateTime eventTime;
     private HttpStatus status;
     private final Integer code;

--- a/src/test/java/cbnu/io/cbnuswalrami/test/acceptance/member/ChangeMemberNicknameAPITest.java
+++ b/src/test/java/cbnu/io/cbnuswalrami/test/acceptance/member/ChangeMemberNicknameAPITest.java
@@ -1,0 +1,114 @@
+package cbnu.io.cbnuswalrami.test.acceptance.member;
+
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.Member;
+import cbnu.io.cbnuswalrami.business.web.member.application.service.ChangeNicknameService;
+import cbnu.io.cbnuswalrami.business.web.member.presentation.ChangeNicknameAPI;
+import cbnu.io.cbnuswalrami.business.web.member.presentation.response.MemberDto;
+import cbnu.io.cbnuswalrami.business.web.util.MemberFindUtil;
+import cbnu.io.cbnuswalrami.common.configuration.container.AcceptanceTestBase;
+import cbnu.io.cbnuswalrami.common.configuration.security.TokenProvider;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.RequestParametersSnippet;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("유저의 닉네임을 변경하는 API 인수트스트")
+class ChangeMemberNicknameAPITest extends AcceptanceTestBase {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    private MockMvc mockMvc;
+
+    @Mock
+    private MemberFindUtil memberFindUtil;
+
+    @InjectMocks
+    private ChangeNicknameAPI changeNicknameAPI;
+
+
+    @BeforeEach
+    public void setUp(RestDocumentationContextProvider restDocumentation) {
+        this.mockMvc = MockMvcBuilders
+                .standaloneSetup(changeNicknameAPI)
+                .apply(
+                        documentationConfiguration(restDocumentation)
+                                .operationPreprocessors()
+                                .withRequestDefaults(prettyPrint())
+                                .withResponseDefaults(prettyPrint())
+                )
+                .build();
+    }
+
+    @Mock
+    private ChangeNicknameService changeNicknameService;
+
+    @DisplayName("유저의 닉네임을 변경하는 기능을 테스트한다.")
+    @Test
+    void given_member_when_change_nickname_then_status_code_200() throws Exception {
+
+        String newNickname = "newNickname";
+        Member member = memberFindUtil.findMemberByAuthentication();
+
+        given(changeNicknameService.changeNickname(newNickname, member)).willReturn(new MemberDto(
+                1L,
+                "changeNickname",
+                2020110110
+        ));
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String token = tokenProvider.createToken(authentication);
+
+        this.mockMvc.perform(put("/api/member/nickname")
+                        .param("nickname", newNickname)
+                        .header("Authorization", "Bearer " + token)
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(document(
+                        "put-member-nickname",
+                        getRequestParametersSnippet(),
+                        getResponseFieldsSnippet()
+                ));
+    }
+
+    private static RequestParametersSnippet getRequestParametersSnippet() {
+        return requestParameters(
+                parameterWithName("nickname").description("바꿀 유저의 닉네임")
+        );
+    }
+
+
+    private static ResponseFieldsSnippet getResponseFieldsSnippet() {
+        return responseFields(
+                fieldWithPath("eventTime").type(JsonFieldType.STRING).description("이벤트 시간"),
+                fieldWithPath("status").type(JsonFieldType.STRING).description("HTTP 상태값"),
+                fieldWithPath("code").type(JsonFieldType.NUMBER).description("HTTP 상태 코드"),
+                fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저의 id값"),
+                fieldWithPath("data.nickname").type(JsonFieldType.STRING).description("바뀐 닉네임"),
+                fieldWithPath("data.studentNumber").type(JsonFieldType.NUMBER).description("유저의 학번")
+        );
+    }
+}

--- a/src/test/java/cbnu/io/cbnuswalrami/test/integration/member/ChangeNicknameTest.java
+++ b/src/test/java/cbnu/io/cbnuswalrami/test/integration/member/ChangeNicknameTest.java
@@ -1,0 +1,68 @@
+package cbnu.io.cbnuswalrami.test.integration.member;
+
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.Member;
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.values.StudentNumber;
+import cbnu.io.cbnuswalrami.business.core.domon.member.infrastructure.command.MemberJpaRepository;
+import cbnu.io.cbnuswalrami.business.web.member.application.service.ChangeNicknameService;
+import cbnu.io.cbnuswalrami.business.web.member.presentation.response.MemberDto;
+import cbnu.io.cbnuswalrami.common.configuration.container.DatabaseTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@DisplayName("멤버 닉네임 변경 통합테스트")
+@ExtendWith(MockitoExtension.class)
+class ChangeNicknameTest extends DatabaseTestBase {
+
+    @InjectMocks
+    private ChangeNicknameService changeNicknameService;
+
+    @Mock
+    private MemberJpaRepository memberJpaRepository;
+
+    @Mock
+    private Member member;
+
+    @DisplayName("31일 지난 멤버의 닉네임을 변경할 수 있다.")
+    @Test
+    void given_valid_change_day_when_change_nickname_then_changed_member() {
+        // Prepare data
+        String newNickname = "newNickname";
+        LocalDateTime lastModifiedDate = LocalDateTime.now().minusDays(31);
+
+        when(member.getLastModifiedAt()).thenReturn(lastModifiedDate);
+        when(member.getId()).thenReturn(1L);
+        when(member.getStudentNumber()).thenReturn(StudentNumber.from(2020110110));
+
+        // Execute
+        MemberDto memberDto = changeNicknameService.changeNickname(newNickname, member);
+
+        // Verify
+        verify(member, times(1)).changeNickname(newNickname);
+        assertEquals(newNickname, memberDto.getNickname());
+    }
+
+
+    @DisplayName("30일 이상 지나지 않은 멤버의 닉네임을 변경할 수 없다.")
+    @Test
+    void invalid_change_day_when_change_nickname_when_illegalargument_exception() {
+        // Prepare data
+        String newNickname = "newNickname";
+        LocalDateTime lastModifiedDate = LocalDateTime.now().minus(29, ChronoUnit.DAYS);
+
+        when(member.getLastModifiedAt()).thenReturn(lastModifiedDate);
+
+        // Execute and assert exception
+        assertThrows(IllegalArgumentException.class, () -> changeNicknameService.changeNickname(newNickname, member));
+    }
+}

--- a/src/test/java/cbnu/io/cbnuswalrami/test/unit/member/MemberTest.java
+++ b/src/test/java/cbnu/io/cbnuswalrami/test/unit/member/MemberTest.java
@@ -19,4 +19,16 @@ class MemberTest {
 
         assertThat(member.getRole()).isEqualTo(STOP_USER);
     }
+
+    @DisplayName("멤버의 닉네임을 변경한다.")
+    @Test
+    void when_change_nickname_then_changed_nickname() {
+        // given
+        String changeNickname = "한글 닉네임😀";
+        Member member = MemberFixture.createMember();
+
+        // when
+        member.changeNickname(changeNickname);
+        assertThat(member.getNickname().getNickname()).isEqualTo(changeNickname);
+    }
 }

--- a/src/test/java/cbnu/io/cbnuswalrami/test/unit/member/NicknameTest.java
+++ b/src/test/java/cbnu/io/cbnuswalrami/test/unit/member/NicknameTest.java
@@ -1,0 +1,58 @@
+package cbnu.io.cbnuswalrami.test.unit.member;
+
+import cbnu.io.cbnuswalrami.business.core.domon.member.entity.values.Nickname;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@DisplayName("닉네임 단위테스트")
+class NicknameTest {
+
+    @Test
+    @DisplayName("Null nickname value throws IllegalArgumentException")
+    void from_null_nickname_throws_exception() {
+        String nullNickname = null;
+
+        assertThrows(IllegalArgumentException.class, () -> Nickname.from(nullNickname));
+    }
+
+    @Test
+    @DisplayName("Nickname value exceeding 39 characters throws IllegalArgumentException")
+    void from_nickname_exceeds_length_throws_exception() {
+        String longNickname = "a".repeat(40);
+
+        assertThrows(IllegalArgumentException.class, () -> Nickname.from(longNickname));
+    }
+
+    @Test
+    @DisplayName("Invalid nickname format throws IllegalArgumentException")
+    void from_invalid_nickname_format_throws_exception() {
+        String invalidNickname = "123";
+
+        assertThrows(IllegalArgumentException.class, () -> Nickname.from(invalidNickname));
+    }
+
+    @Test
+    @DisplayName("Valid nickname returns Nickname object")
+    void from_valid_nickname_returns_nickname() {
+        String validNickname = "validNickname";
+
+        Nickname nickname = Nickname.from(validNickname);
+
+        assertNotNull(nickname);
+        assertEquals(validNickname, nickname.getNickname());
+    }
+
+    @Test
+    @DisplayName("Nickname toString returns string representation of nickname")
+    void to_string_returns_string_representation_of_nickname() {
+        String validNickname = "validNickname";
+
+        Nickname nickname = Nickname.from(validNickname);
+
+        assertEquals(validNickname, nickname.toString());
+    }
+}


### PR DESCRIPTION
## Todo
- [x] API 개발
- [x] 통합테스트 작성
- [x] 인수테스트 작성
- [x] API 문서화 작성

마지막 개인정보 변경이 30일 이상 지나야 가능함으로 API 테스트에서는 모킹을 사용하였다.

issue #46 